### PR TITLE
Merge payload-response delta feature

### DIFF
--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -99,18 +99,19 @@ type ScraperResult struct {
 }
 
 type Result struct {
-	Input            map[string][]byte   `json:"input"`
-	Position         int                 `json:"position"`
-	StatusCode       int64               `json:"status"`
-	ContentLength    int64               `json:"length"`
-	ContentWords     int64               `json:"words"`
-	ContentLines     int64               `json:"lines"`
-	ContentType      string              `json:"content-type"`
-	RedirectLocation string              `json:"redirectlocation"`
-	Url              string              `json:"url"`
-	Duration         time.Duration       `json:"duration"`
-	ScraperData      map[string][]string `json:"scraper"`
-	ResultFile       string              `json:"resultfile"`
-	Host             string              `json:"host"`
-	HTMLColor        string              `json:"-"`
+	Input                map[string][]byte   `json:"input"`
+	Position             int                 `json:"position"`
+	StatusCode           int64               `json:"status"`
+	ContentLength        int64               `json:"length"`
+	ContentWords         int64               `json:"words"`
+	ContentLines         int64               `json:"lines"`
+	ContentType          string              `json:"content-type"`
+	PayloadResponseDelta int64               `json:"pr-delta"`
+	RedirectLocation     string              `json:"redirectlocation"`
+	Url                  string              `json:"url"`
+	Duration             time.Duration       `json:"duration"`
+	ScraperData          map[string][]string `json:"scraper"`
+	ResultFile           string              `json:"resultfile"`
+	Host                 string              `json:"host"`
+	HTMLColor            string              `json:"-"`
 }

--- a/pkg/output/file_csv.go
+++ b/pkg/output/file_csv.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
-var staticheaders = []string{"url", "redirectlocation", "position", "status_code", "content_length", "content_words", "content_lines", "content_type", "duration", "resultfile", "Ffufhash"}
+var staticheaders = []string{"url", "redirectlocation", "position", "status_code", "content_length", "content_words", "content_lines", "content_type", "payload_response_delta", "duration", "resultfile", "Ffufhash"}
 
 func writeCSV(filename string, config *ffuf.Config, res []ffuf.Result, encode bool) error {
 	header := make([]string, 0)
@@ -69,6 +69,7 @@ func toCSV(r ffuf.Result) []string {
 	res = append(res, strconv.FormatInt(r.ContentWords, 10))
 	res = append(res, strconv.FormatInt(r.ContentLines, 10))
 	res = append(res, r.ContentType)
+	res = append(res, strconv.FormatInt(r.PayloadResponseDelta, 10))
 	res = append(res, r.Duration.String())
 	res = append(res, r.ResultFile)
 	res = append(res, ffufhash)

--- a/pkg/output/file_csv_test.go
+++ b/pkg/output/file_csv_test.go
@@ -17,6 +17,7 @@ func TestToCSV(t *testing.T) {
 		ContentWords:     4,
 		ContentLines:     5,
 		ContentType:      "application/json",
+        PayloadResponseDelta: 1,
 		RedirectLocation: "http://no.pe",
 		Url:              "http://as.df",
 		Duration:         time.Duration(123),
@@ -36,6 +37,7 @@ func TestToCSV(t *testing.T) {
 		"4",
 		"5",
 		"application/json",
+        "1",
 		"123ns",
 		"resultfile",
 		"A"}) {

--- a/pkg/output/file_html.go
+++ b/pkg/output/file_html.go
@@ -10,21 +10,22 @@ import (
 )
 
 type htmlResult struct {
-	Input            map[string]string
-	Position         int
-	StatusCode       int64
-	ContentLength    int64
-	ContentWords     int64
-	ContentLines     int64
-	ContentType      string
-	RedirectLocation string
-	ScraperData      string
-	Duration         time.Duration
-	ResultFile       string
-	Url              string
-	Host             string
-	HTMLColor        string
-	FfufHash         string
+	Input                map[string]string
+	Position             int
+	StatusCode           int64
+	ContentLength        int64
+	ContentWords         int64
+	ContentLines         int64
+	ContentType          string
+	PayloadResponseDelta int64
+	RedirectLocation     string
+	ScraperData          string
+	Duration             time.Duration
+	ResultFile           string
+	Url                  string
+	Host                 string
+	HTMLColor            string
+	FfufHash             string
 }
 
 type htmlFileOutput struct {
@@ -96,6 +97,7 @@ const (
               <th>Words</th>
 			  <th>Lines</th>
 			  <th>Type</th>
+              <th>Payload Response Delta</th>
               <th>Duration</th>
 			  <th>Resultfile</th>
               <th>Scraper data</th>
@@ -106,7 +108,7 @@ const (
         <tbody>
 			{{range $result := .Results}}
                 <div style="display:none">
-|result_raw|{{ $result.StatusCode }}{{ range $keyword, $value := $result.Input }}|{{ $value | printf "%s" }}{{ end }}|{{ $result.Url }}|{{ $result.RedirectLocation }}|{{ $result.Position }}|{{ $result.ContentLength }}|{{ $result.ContentWords }}|{{ $result.ContentLines }}|{{ $result.ContentType }}|{{ $result.Duration }}|{{ $result.ResultFile }}|{{ $result.ScraperData }}|{{ $result.FfufHash }}|
+|result_raw|{{ $result.StatusCode }}{{ range $keyword, $value := $result.Input }}|{{ $value | printf "%s" }}{{ end }}|{{ $result.Url }}|{{ $result.RedirectLocation }}|{{ $result.Position }}|{{ $result.ContentLength }}|{{ $result.ContentWords }}|{{ $result.ContentLines }}|{{ $result.ContentType }}|{{ $result.PayloadResponseDelta }}|{{ $result.Duration }}|{{ $result.ResultFile }}|{{ $result.ScraperData }}|{{ $result.FfufHash }}|
                 </div>
                 <tr class="result-{{ $result.StatusCode }}" style="background-color: {{ $result.HTMLColor }};">
                     <td><font color="black" class="status-code">{{ $result.StatusCode }}</font></td>
@@ -120,6 +122,7 @@ const (
                     <td>{{ $result.ContentWords }}</td>
 					<td>{{ $result.ContentLines }}</td>
 					<td>{{ $result.ContentType }}</td>
+					<td>{{ $result.PayloadResponseDelta }}</td>
 					<td>{{ $result.Duration }}</td>
                     <td>{{ $result.ResultFile }}</td>
 					<td>{{ $result.ScraperData }}</td>
@@ -237,21 +240,22 @@ func writeHTML(filename string, config *ffuf.Config, results []ffuf.Result) erro
 			}
 		}
 		hres := htmlResult{
-			Input:            strinput,
-			Position:         r.Position,
-			StatusCode:       r.StatusCode,
-			ContentLength:    r.ContentLength,
-			ContentWords:     r.ContentWords,
-			ContentLines:     r.ContentLines,
-			ContentType:      r.ContentType,
-			RedirectLocation: r.RedirectLocation,
-			ScraperData:      strscraper,
-			Duration:         r.Duration,
-			ResultFile:       r.ResultFile,
-			Url:              r.Url,
-			Host:             r.Host,
-			HTMLColor:        r.HTMLColor,
-			FfufHash:         ffufhash,
+			Input:                strinput,
+			Position:             r.Position,
+			StatusCode:           r.StatusCode,
+			ContentLength:        r.ContentLength,
+			ContentWords:         r.ContentWords,
+			ContentLines:         r.ContentLines,
+			ContentType:          r.ContentType,
+			PayloadResponseDelta: r.PayloadResponseDelta,
+			RedirectLocation:     r.RedirectLocation,
+			ScraperData:          strscraper,
+			Duration:             r.Duration,
+			ResultFile:           r.ResultFile,
+			Url:                  r.Url,
+			Host:                 r.Host,
+			HTMLColor:            r.HTMLColor,
+			FfufHash:             ffufhash,
 		}
 		htmlResults = append(htmlResults, hres)
 	}

--- a/pkg/output/file_json.go
+++ b/pkg/output/file_json.go
@@ -16,19 +16,20 @@ type ejsonFileOutput struct {
 }
 
 type JsonResult struct {
-	Input            map[string]string   `json:"input"`
-	Position         int                 `json:"position"`
-	StatusCode       int64               `json:"status"`
-	ContentLength    int64               `json:"length"`
-	ContentWords     int64               `json:"words"`
-	ContentLines     int64               `json:"lines"`
-	ContentType      string              `json:"content-type"`
-	RedirectLocation string              `json:"redirectlocation"`
-	ScraperData      map[string][]string `json:"scraper"`
-	Duration         time.Duration       `json:"duration"`
-	ResultFile       string              `json:"resultfile"`
-	Url              string              `json:"url"`
-	Host             string              `json:"host"`
+	Input                map[string]string   `json:"input"`
+	Position             int                 `json:"position"`
+	StatusCode           int64               `json:"status"`
+	ContentLength        int64               `json:"length"`
+	ContentWords         int64               `json:"words"`
+	ContentLines         int64               `json:"lines"`
+	ContentType          string              `json:"content-type"`
+	PayloadResponseDelta int64               `json:"payload-response-delta"`
+	RedirectLocation     string              `json:"redirectlocation"`
+	ScraperData          map[string][]string `json:"scraper"`
+	Duration             time.Duration       `json:"duration"`
+	ResultFile           string              `json:"resultfile"`
+	Url                  string              `json:"url"`
+	Host                 string              `json:"host"`
 }
 
 type jsonFileOutput struct {
@@ -66,19 +67,20 @@ func writeJSON(filename string, config *ffuf.Config, res []ffuf.Result) error {
 			strinput[k] = string(v)
 		}
 		jsonRes = append(jsonRes, JsonResult{
-			Input:            strinput,
-			Position:         r.Position,
-			StatusCode:       r.StatusCode,
-			ContentLength:    r.ContentLength,
-			ContentWords:     r.ContentWords,
-			ContentLines:     r.ContentLines,
-			ContentType:      r.ContentType,
-			RedirectLocation: r.RedirectLocation,
-			ScraperData:      r.ScraperData,
-			Duration:         r.Duration,
-			ResultFile:       r.ResultFile,
-			Url:              r.Url,
-			Host:             r.Host,
+			Input:                strinput,
+			Position:             r.Position,
+			StatusCode:           r.StatusCode,
+			ContentLength:        r.ContentLength,
+			ContentWords:         r.ContentWords,
+			ContentLines:         r.ContentLines,
+			ContentType:          r.ContentType,
+			PayloadResponseDelta: r.PayloadResponseDelta,
+			RedirectLocation:     r.RedirectLocation,
+			ScraperData:          r.ScraperData,
+			Duration:             r.Duration,
+			ResultFile:           r.ResultFile,
+			Url:                  r.Url,
+			Host:                 r.Host,
 		})
 	}
 	outJSON := jsonFileOutput{

--- a/pkg/output/file_md.go
+++ b/pkg/output/file_md.go
@@ -14,9 +14,9 @@ const (
   Command line : ` + "`{{.CommandLine}}`" + `
   Time: ` + "{{ .Time }}" + `
 
-  {{ range .Keys }}| {{ . }} {{ end }}| URL | Redirectlocation | Position | Status Code | Content Length | Content Words | Content Lines | Content Type | Duration | ResultFile | ScraperData | Ffufhash
-  {{ range .Keys }}| :- {{ end }}| :-- | :--------------- | :---- | :------- | :---------- | :------------- | :------------ | :--------- | :----------- | :------------ | :-------- |
-  {{range .Results}}{{ range $keyword, $value := .Input }}| {{ $value | printf "%s" }} {{ end }}| {{ .Url }} | {{ .RedirectLocation }} | {{ .Position }} | {{ .StatusCode }} | {{ .ContentLength }} | {{ .ContentWords }} | {{ .ContentLines }} | {{ .ContentType }} | {{ .Duration}} | {{ .ResultFile }} | {{ .ScraperData }} | {{ .FfufHash }}
+  {{ range .Keys }}| {{ . }} {{ end }}| URL | Redirectlocation | Position | Status Code | Content Length | Content Words | Content Lines | Content Type | Payload Response Delta | Duration | ResultFile | ScraperData | Ffufhash
+  {{ range .Keys }}| :- {{ end }} | ---- | ---------------- | -------- | ----------- | -------------- | -------------- | ------------- | ------------------------ | ------------ | ------------- | ----------- | -------- | -------- |
+  {{range .Results}}{{ range $keyword, $value := .Input }}| {{ $value | printf "%s" }} {{ end }}| {{ .Url }} | {{ .RedirectLocation }} | {{ .Position }} | {{ .StatusCode }} | {{ .ContentLength }} | {{ .ContentWords }} | {{ .ContentLines }} | {{ .ContentType }} | {{.PayloadResponseDelta}} | {{ .Duration}} | {{ .ResultFile }} | {{ .ScraperData }} | {{ .FfufHash }}
   {{end}}` // The template format is not pretty but follows the markdown guide
 )
 
@@ -56,20 +56,21 @@ func writeMarkdown(filename string, config *ffuf.Config, results []ffuf.Result) 
 			}
 		}
 		hres := htmlResult{
-			Input:            strinput,
-			Position:         r.Position,
-			StatusCode:       r.StatusCode,
-			ContentLength:    r.ContentLength,
-			ContentWords:     r.ContentWords,
-			ContentLines:     r.ContentLines,
-			ContentType:      r.ContentType,
-			RedirectLocation: r.RedirectLocation,
-			ScraperData:      strscraper,
-			Duration:         r.Duration,
-			ResultFile:       r.ResultFile,
-			Url:              r.Url,
-			Host:             r.Host,
-			FfufHash:         ffufhash,
+			Input:                strinput,
+			Position:             r.Position,
+			StatusCode:           r.StatusCode,
+			ContentLength:        r.ContentLength,
+			ContentWords:         r.ContentWords,
+			ContentLines:         r.ContentLines,
+			ContentType:          r.ContentType,
+			PayloadResponseDelta: r.PayloadResponseDelta,
+			RedirectLocation:     r.RedirectLocation,
+			ScraperData:          strscraper,
+			Duration:             r.Duration,
+			ResultFile:           r.ResultFile,
+			Url:                  r.Url,
+			Host:                 r.Host,
+			FfufHash:             ffufhash,
 		}
 		htmlResults = append(htmlResults, hres)
 	}

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -320,23 +320,32 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 	}
 
 	inputs := make(map[string][]byte, len(resp.Request.Input))
+	inputLength := 0
+
 	for k, v := range resp.Request.Input {
 		inputs[k] = v
+
+        // calculate the sum of all input payloads, excluding the FFUFHASH input
+        if k != "FFUFHASH" {
+		    inputLength = inputLength + len(v)
+        }
 	}
+
 	sResult := ffuf.Result{
-		Input:            inputs,
-		Position:         resp.Request.Position,
-		StatusCode:       resp.StatusCode,
-		ContentLength:    resp.ContentLength,
-		ContentWords:     resp.ContentWords,
-		ContentLines:     resp.ContentLines,
-		ContentType:      resp.ContentType,
-		RedirectLocation: resp.GetRedirectLocation(false),
-		ScraperData:      resp.ScraperData,
-		Url:              resp.Request.Url,
-		Duration:         resp.Duration,
-		ResultFile:       resp.ResultFile,
-		Host:             resp.Request.Host,
+		Input:                inputs,
+		Position:             resp.Request.Position,
+		StatusCode:           resp.StatusCode,
+		ContentLength:        resp.ContentLength,
+		ContentWords:         resp.ContentWords,
+		ContentLines:         resp.ContentLines,
+		ContentType:          resp.ContentType,
+		PayloadResponseDelta: resp.ContentLength - int64(inputLength),
+		RedirectLocation:     resp.GetRedirectLocation(false),
+		ScraperData:          resp.ScraperData,
+		Url:                  resp.Request.Url,
+		Duration:             resp.Duration,
+		ResultFile:           resp.ResultFile,
+		Host:                 resp.Request.Host,
 	}
 	s.CurrentResults = append(s.CurrentResults, sResult)
 	// Output the result
@@ -446,7 +455,7 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
+	resnormal := fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Δ: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.PayloadResponseDelta, res.Duration.Milliseconds(), ANSI_CLEAR)
 	fmt.Println(resnormal)
 }
 


### PR DESCRIPTION
# Description

This PR merges an additional output field called "payload response delta". This is the sum of all the input lengths for a given request subtracted from the payload response length. This allows the user to quickly see if payloads are reflected in content and search for interesting transformations, such as decoding of certain chars. 

The following example shows the payload/response delta value being stable across multiple different payload lengths, suggesting input reflection (and a cross-site scripting vulnerability) and also shows the user that the server is URL decoding input before reflecting.

```
$ ./ffuf -w wordlist:FUZZ -X POST -u "https://xss-686635.securityknowledgeframework-labs.org/home" -H 'content-type: application/x-www-form-urlencoded' -d "string=FUZZ" -mc all

        /'___\  /'___\           /'___\       
       /\ \__/ /\ \__/  __  __  /\ \__/       
       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\      
        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/      
         \ \_\   \ \_\  \ \____/  \ \_\       
          \/_/    \/_/   \/___/    \/_/       

       v2.1.0-dev
________________________________________________

 :: Method           : POST
 :: URL              : https://xss-686635.securityknowledgeframework-labs.org/home
 :: Wordlist         : FUZZ: /home/doi/go/src/github.com/denandz/ffuf/wordlist
 :: Header           : content-type: [application/x-www-form-urlencoded]
 :: Data             : string=FUZZ
 :: Follow redirects : false
 :: Calibration      : false
 :: Timeout          : 10
 :: Threads          : 40
 :: Matcher          : Response status: all
________________________________________________

%41%41%41%41            [Status: 200, Size: 9666, Words: 852, Lines: 227, Δ: 9654, Duration: 307ms]
<script>alert(1)</script> [Status: 200, Size: 9687, Words: 852, Lines: 227, Δ: 9662, Duration: 306ms]
bbq                     [Status: 200, Size: 9665, Words: 852, Lines: 227, Δ: 9662, Duration: 307ms]
'"';                    [Status: 200, Size: 9666, Words: 852, Lines: 227, Δ: 9662, Duration: 307ms]
asdf                    [Status: 200, Size: 9666, Words: 852, Lines: 227, Δ: 9662, Duration: 306ms]
w                       [Status: 200, Size: 9663, Words: 852, Lines: 227, Δ: 9662, Duration: 307ms]
test                    [Status: 200, Size: 9666, Words: 852, Lines: 227, Δ: 9662, Duration: 307ms]
<h1>foo</h1>            [Status: 200, Size: 9674, Words: 852, Lines: 227, Δ: 9662, Duration: 307ms]
AAAAAAHHHFHIWYUBNEF     [Status: 200, Size: 9681, Words: 852, Lines: 227, Δ: 9662, Duration: 306ms]
{{}}                    [Status: 200, Size: 9666, Words: 852, Lines: 227, Δ: 9662, Duration: 306ms]
1                       [Status: 200, Size: 9663, Words: 852, Lines: 227, Δ: 9662, Duration: 306ms]
omg                     [Status: 200, Size: 9665, Words: 852, Lines: 227, Δ: 9662, Duration: 308ms]
:: Progress: [12/12] :: Job [1/1] :: 0 req/sec :: Duration: [0:00:01] :: Errors: 0 ::
```